### PR TITLE
Fixes to make the tests pass, and addition of QuickStart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 A coupled 1D plasma transport (`transport_1d.m`) and cold plasma wave solver (`rf_wave_sol.m`) to determine ponderomotive effects in a fusion plasma close to radio-frequency antenna. 
 
+## Quickstart
+
+```
+git clone https://github.com/rhealbarnett/rf-transpond.git
+cd rf-transpond
+addpath(genpath('./'))
+runtests
+```
+
 ## `rf_wave_sol.m` ##
 
 Solves the frequency domain cold plasma wave equation along one axis. The electric field solution is calculated along *z* using a second order central finite difference scheme, with wavenumbers required for *x* and *y*. The three equations corresponding to each electric field component are written in matrix form, and a solution found using Matlab's \ operator. 

--- a/functions/kz_spectrum.m
+++ b/functions/kz_spectrum.m
@@ -48,7 +48,7 @@ function [actkz,dk] = kz_spectrum(n_new,q_s,m_s,om,npts,damp_len,dampFac,zax,ky,
         hold on
         plot(log10(n_new), expkz,'-.r','Linewidth',2)
         c = colorbar;
-        colormap(magma)
+        %colormap(magma)
         caxis([0 5.0e-5])
         ylim([0 50])
         yticks(linspace(0,50,11))

--- a/rf_transp_test.m
+++ b/rf_transp_test.m
@@ -1,4 +1,4 @@
-function tests = rf_transp_tests
+function tests = rf_transp_test
 
     tests = functiontests(localfunctions);
 

--- a/rms.m
+++ b/rms.m
@@ -1,0 +1,5 @@
+function ans = rms(x)
+
+ans = sqrt(mean(x.^2));
+
+end


### PR DESCRIPTION
Passes now ... 

```
>> runtests
Running rf_transp_test

=======================================
 Running wave solver dispersion verification
=======================================
.
=======================================
 Running steady state transport MMS
=======================================
iteration 1
Number of points 512
Minimum dx 7.591434e-04
Maximum dx 1.802196e-03
tolerance reached, ii=17
velocity rms error = 4.791096e-13
density rms error = 9.230712e-14
iteration 2
Number of points 256
Minimum dx 7.591434e-04
Maximum dx 1.802196e-03
tolerance reached, ii=17
velocity rms error = 4.028605e-13
density rms error = 8.644165e-14
iteration 3
Number of points 128
Minimum dx 1.528856e-03
Maximum dx 3.618526e-03
tolerance reached, ii=17
velocity rms error = 3.564956e-13
density rms error = 9.195429e-14
iteration 4
Number of points 64
Minimum dx 3.100786e-03
Maximum dx 7.294028e-03
tolerance reached, ii=17
velocity rms error = 3.214361e-13
density rms error = 1.135820e-13
iteration 5
Number of points 32
Minimum dx 6.380488e-03
Maximum dx 1.481945e-02
tolerance reached, ii=16
velocity rms error = 8.993228e-13
density rms error = 3.799760e-13
.
=======================================
 Running time dependent transport MMS
=======================================
iteration 1
Time step 8.000000e-06
nmax, tmax 100, 8.000000e-04
At iteration 20 of 100, time elapsed 0.04 s.
At iteration 40 of 100, time elapsed 0.06 s.
At iteration 60 of 100, time elapsed 0.07 s.
At iteration 80 of 100, time elapsed 0.09 s.
At iteration 100 of 100, time elapsed 0.11 s.
Elapsed time is 0.110281 seconds.
iteration 2
Time step 4.000000e-06
nmax, tmax 200, 8.000000e-04
At iteration 40 of 200, time elapsed 0.04 s.
At iteration 80 of 200, time elapsed 0.07 s.
At iteration 120 of 200, time elapsed 0.09 s.
At iteration 160 of 200, time elapsed 0.11 s.
At iteration 200 of 200, time elapsed 0.13 s.
Elapsed time is 0.132839 seconds.
iteration 3
Time step 2.000000e-06
nmax, tmax 400, 8.000000e-04
At iteration 80 of 400, time elapsed 0.04 s.
At iteration 160 of 400, time elapsed 0.08 s.
At iteration 240 of 400, time elapsed 0.12 s.
At iteration 320 of 400, time elapsed 0.16 s.
At iteration 400 of 400, time elapsed 0.20 s.
Elapsed time is 0.198569 seconds.
iteration 4
Time step 1.000000e-06
nmax, tmax 800, 8.000000e-04
At iteration 160 of 800, time elapsed 0.08 s.
At iteration 320 of 800, time elapsed 0.15 s.
At iteration 480 of 800, time elapsed 0.24 s.
At iteration 640 of 800, time elapsed 0.31 s.
At iteration 800 of 800, time elapsed 0.38 s.
Elapsed time is 0.380064 seconds.
iteration 5
Time step 5.000000e-07
nmax, tmax 1600, 8.000000e-04
At iteration 320 of 1600, time elapsed 0.13 s.
At iteration 640 of 1600, time elapsed 0.28 s.
At iteration 960 of 1600, time elapsed 0.43 s.
At iteration 1280 of 1600, time elapsed 0.57 s.
At iteration 1600 of 1600, time elapsed 0.70 s.
Elapsed time is 0.701310 seconds.
.
Done rf_transp_test
__________


ans = 

  1×3 TestResult array with properties:

    Name
    Passed
    Failed
    Incomplete
    Duration
    Details

Totals:
   3 Passed, 0 Failed, 0 Incomplete.
   31.7489 seconds testing time.
```